### PR TITLE
Set some sensible defaults and custom fixes

### DIFF
--- a/shaders/las_points.glsl
+++ b/shaders/las_points.glsl
@@ -6,15 +6,16 @@ uniform mat4 modelViewMatrix;
 uniform mat4 projectionMatrix;
 uniform mat4 modelViewProjectionMatrix;
 
+// las_points shader
 //------------------------------------------------------------------------------
 #if defined(VERTEX_SHADER)
 
-uniform float pointRadius = 0.1;    //# uiname=Point Radius; min=0.001; max=10
+uniform float pointRadius = 0.05;   //# uiname=Point Radius (m); min=0.001; max=10
 uniform float trimRadius = 1000000; //# uiname=Trim Radius; min=1; max=1000000
 uniform float reference = 400.0;    //# uiname=Reference Intensity; min=0.001; max=100000
 uniform float exposure = 1.0;       //# uiname=Exposure; min=0.001; max=10000
 uniform float contrast = 1.0;       //# uiname=Contrast; min=0.001; max=10000
-uniform int colorMode = 0;          //# uiname=Colour Mode; enum=Intensity|Colour|Return Index|Point Source|Las Classification|File Number|Distance
+uniform int colorMode = 1;          //# uiname=Colour Mode; enum=Intensity|Colour|Return Index|Point Source|Las Classification|File Number|Distance
 uniform int selectionMode = 0;      //# uiname=Selection; enum=All|Classified|First Return|Last Return|First Of Several
 uniform float minPointSize = 0;
 uniform float maxPointSize = 400.0;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -305,6 +305,7 @@ MainWindow::MainWindow(const QGLFormat& format)
     m_hookManager = new HookManager(this);
 
     readSettings();
+    this->showMaximized();
 }
 
 void MainWindow::startIpcServer(const QString& socketName)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
     int maxPointCount = -1;
     std::string serverName = "default";
     double posX = -DBL_MAX, posY = -DBL_MAX, posZ = -DBL_MAX;
-    double yaw = -DBL_MAX, pitch = -DBL_MAX, roll = -DBL_MAX;
+    double yaw = 90, pitch = 0, roll = 0;
     double rot[9] = {-DBL_MAX,-DBL_MAX,-DBL_MAX,-DBL_MAX,-DBL_MAX,-DBL_MAX,-DBL_MAX,-DBL_MAX,-DBL_MAX}; // Camera rotation matrix
     double viewRadius = -DBL_MAX;
 

--- a/src/render/PointArray.cpp
+++ b/src/render/PointArray.cpp
@@ -212,7 +212,7 @@ bool PointArray::loadText(QString fileName, size_t maxPointCount,
     Imath::V3d p;
     size_t readCount = 0;
     // Read three doubles; "%*[^\n]" discards up to just before end of line
-    while (fscanf(inFile, " %lf %lf %lf%*[^\n]", &p.x, &p.y, &p.z) == 3)
+    while (fscanf(inFile, " %lf%*c%lf%*c%lf%*[^\n]", &p.x, &p.y, &p.z) == 3)
     {
         points.push_back(p);
         ++readCount;

--- a/src/render/View3D.cpp
+++ b/src/render/View3D.cpp
@@ -36,7 +36,7 @@ View3D::View3D(GeometryCollection* geometries, const QGLFormat& format, QWidget 
     m_explicitCursorPos(false),
     m_cursorPos(0),
     m_prevCursorSnap(0),
-    m_backgroundColor(60, 50, 50),
+    m_backgroundColor(211, 211, 211), //lightgrey
     m_drawBoundingBoxes(false),
     m_drawCursor(true),
     m_drawAxes(true),


### PR DESCRIPTION
Set:
* Default camera views for OreSense LAS CRS.
* Main view background colour (light grey).
* Point radius to 50mm.
* Choose to view Colours on the points as default.
* A fix for reading CSV files (from Jared I think).
* Set the main application window to maximized on startup.